### PR TITLE
Make this quickstart example compile with Scala 3

### DIFF
--- a/src/main/scala/dev/zio/quickstart/MainApp.scala
+++ b/src/main/scala/dev/zio/quickstart/MainApp.scala
@@ -32,7 +32,7 @@ object MainApp extends ZIOAppDefault {
       Server
         .start(
           port = 8088,
-          http = Http.collectHttp { case _ -> !! / "api" / "graphql" =>
+          http = Http.collectHttp[Request] { case _ -> !! / "api" / "graphql" =>
             ZHttpAdapter.makeHttpService(interpreter)
           }
         )


### PR DESCRIPTION
To compile with Scala 3 a type annotation to Http.collectHttp is neccessary. See https://github.com/ghostdogpr/caliban/issues/1442#issuecomment-1214748869